### PR TITLE
Make context-sniffing compatible with Node

### DIFF
--- a/webcrypto-shim.js
+++ b/webcrypto-shim.js
@@ -3,9 +3,9 @@
  * @author Artem S Vybornov <vybornov@gmail.com>
  * @license MIT
  */
+
 !function ( global ) {
     'use strict';
-
     if ( typeof Promise !== 'function' )
         throw "Promise support required";
 
@@ -594,4 +594,4 @@
         global.SubtleCrypto = _SubtleCrypto;
         global.CryptoKey = CryptoKey;
     }
-}( typeof window === 'undefined' ? typeof 'self' === 'undefined' ? this : self : window );
+}( typeof window === 'undefined' ? typeof self === 'undefined' ? this : self : window );

--- a/webcrypto-shim.js
+++ b/webcrypto-shim.js
@@ -3,9 +3,9 @@
  * @author Artem S Vybornov <vybornov@gmail.com>
  * @license MIT
  */
-
 !function ( global ) {
     'use strict';
+
     if ( typeof Promise !== 'function' )
         throw "Promise support required";
 


### PR DESCRIPTION
Even though this module is intended to be ran in a browser context, it will fail in its current state when using babel (or other node libs), due to check for `typeof 'self' === 'undefined'` - which will return a string in both browser and node.

The correct version `typeof self === 'undefined'` will work as expected.

PS: It would be nice if the merged master are re-published on npm to ease the install-process through `package.json` / `npm install`