### PR TITLE
Safari 11 supports web crypto without the prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ Supported browsers
 
 The library is targeted to fix these browsers having prefixed and buggy webcrypto api implementations:
 * _Internet Explorer 11_, _Mobile Internet Explorer 11_,
-* _Safari 8+_, _iOS Safari 8+_.
+* _Safari 8 - 10_, _iOS Safari 8 - 10_.
 
 These browsers have unprefixed and conforming webcrypto api implementations, so no need in shim:
 * _Chrome 43+_, _Chrome for Android 44+_,
 * _Opera 24+_,
 * _Firefox 34+_,
 * _Edge 12+_.
+* _Safari 11+_.
 
 Crossbrowser support of algorithms & operations
 -----------------------------------------------


### PR DESCRIPTION
According to caniuse: https://github.com/Fyrd/caniuse/commit/4360d4e453d2c760386386093b0c085dbc6981fd#diff-435cb8c7f19dc6b0f8588ffe0baabd77