### PR TITLE
Converts webcrypto-shim into a UMD module

### DIFF
--- a/webcrypto-shim.js
+++ b/webcrypto-shim.js
@@ -3,7 +3,19 @@
  * @author Artem S Vybornov <vybornov@gmail.com>
  * @license MIT
  */
-!function ( global ) {
+(function (global, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], function () {
+            return factory(global);
+        });
+    } else if (typeof module === 'object' && module.exports) {
+        // CommonJS-like environments that support module.exports
+        module.exports = factory(global);
+    } else {
+        factory(global);
+    }
+}(typeof self !== 'undefined' ? self : this, function (global) {
     'use strict';
 
     if ( typeof Promise !== 'function' )
@@ -595,4 +607,4 @@
         global.SubtleCrypto = _SubtleCrypto;
         global.CryptoKey = CryptoKey;
     }
-}( typeof window === 'undefined' ? typeof self === 'undefined' ? this : self : window );
+}));


### PR DESCRIPTION
Modifies webcrypto-shim to be AMD aware and to work with CommonJS

This UMD wrapping was added as a general improvement for webcrypto-shim. Due to the hard dependency of a promise library, it is essential that Promise is fully available when webcrypto-shim is used. As many promise libraries are AMD aware, adding AMD support improves the usability of this library with many existing promise libraries.

In our particular case, our promise library is AMD aware as well as the majority of the project. The hard dependency of Promise in webcrypto-shim caused a problem. The promise library was not compatible with non-AMD libraries and therefore could not be included as a dependency. This UMD wrapping was key to resolving our issue.