### PR TITLE
Change gulp to a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "oaep",
     "pkcs1"
   ],
-  "dependencies": {
+  "devDependencies": {
     "gulp": "latest",
     "gulp-sourcemaps":"latest",
     "gulp-uglify":"latest",


### PR DESCRIPTION
Thanks for the project!

Currently gulp (and its related packages) are installed when webcrypto-shim is included as a dependency. Moving gulp to a devDependency means webcrypto-shim will install faster and will avoid gulp-related issues. As currently configured, I get an `npm WARN deprecated graceful-fs` warning that's due to a gulp dependency when installing webcrypto-shim.