### PR TITLE
Add default tagLength for AES-GCM in Internet Explorer

### DIFF
--- a/test/alg/aes-gcm.js
+++ b/test/alg/aes-gcm.js
@@ -37,4 +37,13 @@ describe( 'AES-GCM' , function () {
             .catch(fail)
             .then(done);
     });
+
+    it( "w/ default tagLength", function ( done ) {
+        genKeyComplete
+            .then( function () {
+                return crypto.subtle.encrypt( extend( alg, { iv: new Uint8Array(12) } ), key, new Uint8Array(16) )
+            })
+            .catch(fail)
+            .then(done);
+    });
 });

--- a/webcrypto-shim.js
+++ b/webcrypto-shim.js
@@ -539,6 +539,10 @@
                     a.tag = (c.buffer || c).slice( c.byteLength - tl );
                 }
 
+                if ( isIE && ka.name === 'AES-GCM' && args[0].tagLength === undefined ) {
+                    args[0].tagLength = 128;
+                }
+
                 args[1] = b._key;
 
                 var op;


### PR DESCRIPTION
While the specification for AesGcmParams defines tagLength as being optional and defaulting to 128, if it is not provided in Internet Explorer, encryption will fail:

>Unable to get property 'message' of undefined or null reference

You can verify this on the [Live Table page](https://vibornoff.github.io/webcrypto-examples/index.html) by pasting the following snippet into the browser console in Internet Explorer:

```js
crypto.subtle.generateKey( { name: 'AES-GCM', length: 256 }, true, [ 'encrypt', 'decrypt' ] )
  .then( function ( key ) {
    return crypto.subtle.encrypt( { name: 'AES-GCM', iv: new Uint8Array(12) }, key, new Uint8Array(16) )
  }).catch( function ( err ) { console.log('Error', err); });
```

The proposed changes assign the default value if it's omitted.

See specification: https://www.w3.org/TR/WebCryptoAPI/#dfn-AesGcmParams

>- If the tagLength member of normalizedAlgorithm is not present:
>   - Let tagLength be 128.

It's not clear to me how to run the included tests, so I've not verified that the tests pass.